### PR TITLE
Google系BoxのPepper2.5.5対応とエラー処理の追加

### DIFF
--- a/web-boxes/Google/Cloud Vision/Label Detection/box.xar
+++ b/web-boxes/Google/Cloud Vision/Label Detection/box.xar
@@ -27,7 +27,7 @@
                          'maxResults': self.getParameter('Max Results')}]
         req_body = {'requests': {'image': req_image, 'features': req_features}}
 
-        response = requests.post(endpoint, json=req_body)
+        response = requests.post(endpoint, data=json.dumps(req_body))
         if response.status_code == requests.codes.ok:
             resp_body = response.json()['responses']
             self.logger.debug(json.dumps(resp_body))

--- a/web-boxes/Google/Cloud Vision/Landmark Detection/box.xar
+++ b/web-boxes/Google/Cloud Vision/Landmark Detection/box.xar
@@ -27,7 +27,7 @@
                          'maxResults': self.getParameter('Max Results')}]
         req_body = {'requests': {'image': req_image, 'features': req_features}}
 
-        response = requests.post(endpoint, json=req_body)
+        response = requests.post(endpoint, data=json.dumps(req_body))
         if response.status_code == requests.codes.ok:
             resp_body = response.json()['responses']
             self.logger.debug(json.dumps(resp_body))

--- a/web-boxes/Google/Cloud Vision/Text Detection/box.xar
+++ b/web-boxes/Google/Cloud Vision/Text Detection/box.xar
@@ -28,7 +28,7 @@
         req_body = {'requests': {'image': req_image, 'features': req_features,
                     'imageContext': {'languageHints': self.getParameter('Languages').split()}}}
 
-        response = requests.post(endpoint, json=req_body)
+        response = requests.post(endpoint, data=json.dumps(req_body))
         if response.status_code == requests.codes.ok:
             resp_body = response.json()['responses']
             self.logger.debug(json.dumps(resp_body))

--- a/web-boxes/Google/Cloud Vision/Text Detection/box.xar
+++ b/web-boxes/Google/Cloud Vision/Text Detection/box.xar
@@ -34,8 +34,10 @@
             self.logger.debug(json.dumps(resp_body))
             if 'textAnnotations' in resp_body[0]:
                 annotations = resp_body[0]['textAnnotations']
-                output = map(lambda a: [a['locale'].encode('utf8'), a['description'].encode('utf8')],
-                             annotations)
+                output = map(lambda a: [
+                                 a['locale'].encode('utf8') if 'locale' in a else None,
+                                 a['description'].encode('utf8') if 'description' in a else None
+                             ], annotations)
                 self.texts(output)
             else:
                 self.texts([])


### PR DESCRIPTION
Google/Cloud Vision の Label Detection, Landmark Detection, Text Detection ボックスを修正しました。

Pepper2.5.5で `requests` ライブラリがダウングレードされ、 `request.post()` で `json` パラメータが使えなくなったため、 `data=json.dumps(...)` に変更しました。

Text Detection ボックスで Annotation Object に locale や description パラメータが含まれていない場合でも動作するように変更しました。